### PR TITLE
Misc fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,8 @@ DEFAULT_MIRROR=http://www.cpan.org/
 
 # CFLAGS= -I. -Iinclude/ -Wall -Werror -std=c99 -g $$(pkg-config --cflags glib-2.0 libcurl)
 # CFLAGS= -I. -Iinclude/ -Wall -std=c99 -g $$(pkg-config --cflags glib-2.0 libcurl) -D_GNU_SOURCE
-CFLAGS= -O3 -I. -Iinclude/ -Wall $$(pkg-config --static --cflags glib-2.0 libcurl) 
-
-CFLAGS+= -lmenu -lncurses 
-
-LDFLAGS= $$(pkg-config --static --libs glib-2.0 libcurl)
+CFLAGS= -O3 -I. -Iinclude/ -Wall $$(pkg-config --static --cflags glib-2.0)
+LDFLAGS= $$(pkg-config --static --libs glib-2.0) -lmenu -lncurses -lcurl
 
 SRCS=src/cpans.c \
 	src/membuf.c \

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,7 @@
 PROG=cpans
 DEFAULT_MIRROR=http://www.cpan.org/
 
-# CFLAGS= -I. -Iinclude/ -Wall -Werror -std=c99 -g $$(pkg-config --cflags glib-2.0 libcurl)
-# CFLAGS= -I. -Iinclude/ -Wall -std=c99 -g $$(pkg-config --cflags glib-2.0 libcurl) -D_GNU_SOURCE
-CFLAGS= -O3 -I. -Iinclude/ -Wall $$(pkg-config --static --cflags glib-2.0)
+CFLAGS=  -Wall -O3 -Iinclude $$(pkg-config --static --cflags glib-2.0)
 LDFLAGS= $$(pkg-config --static --libs glib-2.0) -lmenu -lncurses -lcurl
 
 SRCS=src/cpans.c \
@@ -29,7 +27,7 @@ $(PROG): $(OBJS)
 
 install: $(PROG)
 		./cpans --fetch $(DEFAULT_MIRROR)
-		mkdir -p    /usr/bin
+		mkdir -p /usr/bin
 		cp -v $(PROG) /usr/bin
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
 PROG=cpans
+DEFAULT_MIRROR=http://www.cpan.org/
 
 # CFLAGS= -I. -Iinclude/ -Wall -Werror -std=c99 -g $$(pkg-config --cflags glib-2.0 libcurl)
 # CFLAGS= -I. -Iinclude/ -Wall -std=c99 -g $$(pkg-config --cflags glib-2.0 libcurl) -D_GNU_SOURCE
@@ -26,11 +27,11 @@ $(PROG): $(OBJS)
 		$(CC) $(CFLAGS) $(LDFLAGS) $(OBJS) -o $(PROG)
 		@echo "----------------"
 		@echo "When you upgrade cpans, please update the source data again with -f option:"
-		@echo "   cpans -f http://cpan.perl.org/"
+		@echo "   cpans -f $(DEFAULT_MIRROR)"
 		@echo "----------------"
 
 install: $(PROG)
-		./cpans --fetch http://cpan.perl.org/
+		./cpans --fetch $(DEFAULT_MIRROR)
 		mkdir -p    /usr/bin
 		cp -v $(PROG) /usr/bin
 

--- a/src/cpans.c
+++ b/src/cpans.c
@@ -9,7 +9,7 @@
 #include "init.h"
 #include "update.h"
 
-#define DEFAULT_MIRROR "http://cpan.perl.org/"
+#define DEFAULT_MIRROR "http://www.cpan.org/"
 
 char version[] = "0.2";
 char ignore_case = 0;

--- a/src/ncurses.c
+++ b/src/ncurses.c
@@ -176,7 +176,7 @@ void install_modules(char * prog, char **nlist , int len, int wait)
         pid = fork();
         if( pid == 0 ) {
             printf( "* Running %s %s\n" , prog , nlist[i] );
-            execl( prog , "" , " " , nlist[i] , 0 );
+            execl( prog , "" , " " , nlist[i] , NULL);
             exit(0);
         }
         if( wait )


### PR DESCRIPTION
Hey Cornelius,

cpansearch has been broken and uncompilable on my machine for awhile.  This branch contains several fixes to help get cpansearch working again.
- The first patch fixes a GCC warning about a missing sentinal.
- The second patch sets www.cpan.org to be the default mirror, since cpan.perl.org provides a 301 Redirect rather than packages.gz.  If cpans tries to unzip the html, it segfaults.
- The third patch gets the build working on OS X by move the -l flags to LDFLAGS and using the system curl
- The fourth patch is just some miscellaneous cleanups to Makefile

Please let me know if you'd like me to make any changes.  Take care and thank you for writing this program.  I've found it very handy.  Have a great new year!

Cheers,
Fitz Elliott
